### PR TITLE
fix for ImportError during installation

### DIFF
--- a/bert/__init__.py
+++ b/bert/__init__.py
@@ -1,8 +1,6 @@
 
 """BERT-RPC Library"""
 
-__version__ = "1.0.0"
-
 from bert.codec import BERTDecoder, BERTEncoder
 from erlastic import Atom
 

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@
 
 from distutils.core import setup
 
-from bert import __version__ as version
+__version__ = '1.0.0'
 
 setup(
     name = 'bert',
-    version = version,
+    version = __version__,
     description = 'BERT Serialization Library',
     author = 'Samuel Stauffer',
     author_email = 'samuel@lefora.com',


### PR DESCRIPTION
`setup.py` is trying to import the version number from the `bert` module, which is importing `erlastic`. This causes an import error when running `python setup.py install` if you don't have `eralstic` already installed.

Here is the full stack trace for the error:

``` python
$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    from bert import __version__ as version
  File "/Users/jordan/projects/opensource/forks/python-bert/bert/__init__.py", line 6, in <module>
    from bert.codec import BERTDecoder, BERTEncoder
  File "/Users/jordan/projects/opensource/forks/python-bert/bert/codec.py", line 6, in <module>
    from erlastic import ErlangTermDecoder, ErlangTermEncoder, Atom
ImportError: No module named erlastic
```

Here is a [similar commit](https://github.com/mjrusso/python-bertrpc/commit/4c59aab95bc314792309cdc31f47e3f5eb4a995e) on a different project that resolves the same issue.
