### PR TITLE
Check that an unicode obj is not an Atom before converting it.

### DIFF
--- a/bert/codec.py
+++ b/bert/codec.py
@@ -84,7 +84,7 @@ class BERTEncoder(object):
             return (Atom("bert"), Atom("false"))
         elif obj is None:
             return (Atom("bert"), Atom("nil"))
-        elif isinstance(obj, unicode):
+        elif isinstance(obj, unicode) and not isinstance(obj, Atom):
             return (Atom("bert"), Atom("string"), Atom(self.encoding.upper()), obj.encode(self.encoding))
         elif isinstance(obj, dict):
             return (Atom("bert"), Atom("dict"), [(self.convert(k), self.convert(v)) for k, v in obj.items()])


### PR DESCRIPTION
Hello Samuel,

This PR makes sure that an object is not an Atom before converting it.
This is required for some different implementation of Python like IronPython where `class Atom(str)` can return `True` for the test `isinstance(obj, unicode)` in certain cases.

Cheers,
syl20bnr
