### PR TITLE
Python 2/3 compatible version

### DIFF
--- a/bert/codec.py
+++ b/bert/codec.py
@@ -5,23 +5,29 @@ import time
 
 from erlastic import ErlangTermDecoder, ErlangTermEncoder, Atom
 
+
 def utc_to_datetime(seconds, microseconds):
     return datetime.datetime.utcfromtimestamp(seconds).replace(microsecond=microseconds)
+
 
 def datetime_to_utc(dt):
     # Can't use time.mktime as it assumes local timezone
     delta = dt - datetime.datetime(1970, 1, 1, 0, 0)
     return delta.days * 24 * 60 * 60 + delta.seconds, dt.microsecond
 
+
 def str_to_list(s):
     return [ord(x) for x in s]
+
 
 def list_to_str(l):
     return "".join(chr(x) for x in l)
 
 RE_TYPE = type(re.compile("foo"))
 
+
 class BERTDecoder(object):
+
     def __init__(self, encoding="utf-8"):
         self.encoding = encoding
         self.erlang_decoder = ErlangTermDecoder()
@@ -68,7 +74,9 @@ class BERTDecoder(object):
             return re.compile(item[2], flags)
         raise NotImplementedError("Unknown BERT type %s" % item[1])
 
+
 class BERTEncoder(object):
+
     def __init__(self, encoding="utf-8"):
         self.encoding = encoding
         self.erlang_encoder = ErlangTermEncoder()
@@ -84,7 +92,7 @@ class BERTEncoder(object):
             return (Atom("bert"), Atom("false"))
         elif obj is None:
             return (Atom("bert"), Atom("nil"))
-        elif isinstance(obj, unicode):
+        elif isinstance(obj, basestring) and not self.__is_ascii(obj):
             return (Atom("bert"), Atom("string"), Atom(self.encoding.upper()), obj.encode(self.encoding))
         elif isinstance(obj, dict):
             return (Atom("bert"), Atom("dict"), [(self.convert(k), self.convert(v)) for k, v in obj.items()])
@@ -109,3 +117,6 @@ class BERTEncoder(object):
                 options.append(Atom('dotall'))
             return (Atom("bert"), Atom("regex"), obj.pattern, tuple(options))
         return obj
+
+    def __is_ascii(self, s):
+        return all(ord(c) < 128 for c in s)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email = 'samuel@descolada.com',
     url = 'http://github.com/samuel/python-bert',
     packages = ['bert'],
-    install_requires = ["erlastic"],
+    install_requires = ["erlastic", "future"],
     classifiers = [
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email = 'samuel@descolada.com',
     url = 'http://github.com/samuel/python-bert',
     packages = ['bert'],
-    install_requires = ["erlastic", "future"],
+    install_requires = ["erlastic"],
     classifiers = [
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',

--- a/tests.py
+++ b/tests.py
@@ -18,11 +18,11 @@ class TestDateConversion(unittest.TestCase):
 
     def testToDatetime(self):
         for dt, tstamp in self.test_dates:
-            self.failUnlessEqual(dt, utc_to_datetime(tstamp[0], tstamp[1]))
+            self.assertEqual(dt, utc_to_datetime(tstamp[0], tstamp[1]))
 
     def testFromDatetime(self):
         for dt, tstamp in self.test_dates:
-            self.failUnlessEqual(tstamp, datetime_to_utc(dt))
+            self.assertEqual(tstamp, datetime_to_utc(dt))
 
 class BERTTestCase(unittest.TestCase):
     bert_tests = [
@@ -55,12 +55,12 @@ class BERTTestCase(unittest.TestCase):
     def testDecode(self):
         convert = BERTDecoder().convert
         for python, bert in self.bert_tests:
-            self.failUnlessEqual(python, convert(bert))
+            self.assertEqual(python, convert(bert))
 
     def testEncode(self):
         convert = BERTEncoder().convert
         for python, bert in self.bert_tests:
-            self.failUnlessEqual(bert, convert(python))
+            self.assertEqual(bert, convert(python))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Basic test passing, further testing is needed. For Python 3 it uses git@github.com:awetzel/python-erlastic.git version which is not compatible with Python 2.